### PR TITLE
Open directory to fsync for write access

### DIFF
--- a/main.js
+++ b/main.js
@@ -110,7 +110,7 @@ function set(key, value, options) {
     .catch(function(_) { return Promise.reject(e); })
   }).then(function() {
     // Fsync the file's directory.
-    return pOpen(path.dirname(key), constants.O_RDONLY);
+    return pOpen(path.dirname(key), constants.O_WRONLY);
   }).then(function(fileDescriptor) {
     fd = fileDescriptor;
     return pFsync(fd);


### PR DESCRIPTION
The `fsync` system call writes to disk all buffered data relating to a file descriptor. When opened with `O_RDONLY`, even though most Linux-based systems will cope, the operation will fail on others, for example Windows. This pull request suggests opening the directory using `O_WRONLY` instead.

A similar discussion can be found [here](https://github.com/nodejs/node/issues/3879).